### PR TITLE
Added some documentation, as well as started cleaning up some code.

### DIFF
--- a/POGOLib/Constants.cs
+++ b/POGOLib/Constants.cs
@@ -1,6 +1,6 @@
 ﻿namespace POGOLib
 {
-    internal static class Configuration
+    internal static class Constants
     {
         public const string ApiUrl = "https://pgorelease.nianticlabs.com/plfe/rpc";
         public const string ApiUserAgent = "Dalvik/2.1.0 (Linux; U; Android 6.0.1; ONEPLUS A3003 Build/MMB29M)";

--- a/POGOLib/Net/Data/AuthData.cs
+++ b/POGOLib/Net/Data/AuthData.cs
@@ -3,14 +3,21 @@ using Newtonsoft.Json;
 
 namespace POGOLib.Net.Data
 {
+    /// <summary>
+    /// Represents the authentication response data.
+    /// </summary>
     public class AuthData
     {
-
+        /// <summary>
+        /// Gets or sets the access token of the <see cref="AuthData"/>.
+        /// </summary>
         [JsonProperty("access_token")]
         public string AccessToken { get; set; }
 
+        /// <summary>
+        /// Gets or sets the expire date of the <see cref="AuthData"/>.
+        /// </summary>
         [JsonProperty("expire_datetime")]
         public DateTime ExpireDateTime { get; set; }
-
     }
 }

--- a/POGOLib/Net/Data/GpsData.cs
+++ b/POGOLib/Net/Data/GpsData.cs
@@ -2,17 +2,27 @@
 
 namespace POGOLib.Net.Data
 {
+    /// <summary>
+    /// Represents a GPS position.
+    /// </summary>
     public class GpsData
     {
-
+        /// <summary>
+        /// Gets or sets the latitude of the <see cref="GpsData"/>.
+        /// </summary>
         [JsonProperty("latitude", Required = Required.Always)]
         public double Latitude { get; set; }
 
+        /// <summary>
+        /// Gets or sets the longitude of the <see cref="GpsData"/>.
+        /// </summary>
         [JsonProperty("longitude", Required = Required.Always)]
         public double Longitude { get; set; }
 
+        /// <summary>
+        /// Gets or sets the altitude of the <see cref="GpsData"/>.
+        /// </summary>
         [JsonProperty("altitude", Required = Required.Always)]
         public double Altitude { get; set; }
-
     }
 }

--- a/POGOLib/Net/Data/Login/LoginData.cs
+++ b/POGOLib/Net/Data/Login/LoginData.cs
@@ -4,12 +4,10 @@ namespace POGOLib.Net.Data.Login
 {
     internal struct LoginData
     {
-
         [JsonProperty("lt", Required = Required.Always)]
         public string Lt { get; set; }
 
         [JsonProperty("execution", Required = Required.Always)]
         public string Execution { get; set; }
-
     }
 }

--- a/POGOLib/Net/Data/SaveData.cs
+++ b/POGOLib/Net/Data/SaveData.cs
@@ -3,20 +3,33 @@ using POGOLib.Pokemon;
 
 namespace POGOLib.Net.Data
 {
+    /// <summary>
+    /// Represents client-side data, used to authenticate through a <see cref="PoClient"/>.
+    /// </summary>
     public class ClientData
     {
-
+        /// <summary>
+        /// Gets or sets the username of the <see cref="ClientData"/>.
+        /// </summary>
         [JsonProperty("username", Required = Required.Always)]
         public string Username { get; set; }
 
+        /// <summary>
+        /// Gets or sets the login provider of the <see cref="ClientData"/>.
+        /// </summary>
         [JsonProperty("login_provider", Required = Required.Always)]
         public LoginProvider LoginProvider { get; set; }
 
+        /// <summary>
+        /// Gets or sets the GPS data of the <see cref="ClientData"/>.
+        /// </summary>
         [JsonProperty("gps_data", Required = Required.Always)]
         public GpsData GpsData { get; set; }
 
+        /// <summary>
+        /// Gets or sets the authentication data of the <see cref="ClientData"/>.
+        /// </summary>
         [JsonProperty("auth_data")]
         public AuthData AuthData { get; set; }
-
     }
 }

--- a/POGOLib/Net/RPCClient.cs
+++ b/POGOLib/Net/RPCClient.cs
@@ -29,11 +29,15 @@ namespace POGOLib.Net
         private string _settingsHash;
         private long _lastInventoryTimestamp;
 
+        /// <summary>
+        /// Initializes an instance of the <see cref="RpcClient"/> class.
+        /// </summary>
+        /// <param name="poClient">The PO client.</param>
         public RpcClient(PoClient poClient)
         {
             _poClient = poClient;
             _httpClient = new HttpClient();
-            _httpClient.DefaultRequestHeaders.UserAgent.TryParseAdd(Configuration.ApiUserAgent);
+            _httpClient.DefaultRequestHeaders.UserAgent.TryParseAdd(Constants.ApiUserAgent);
             _requestId = (ulong) new Random().Next(100000000, 999999999);
             _apiUrl = $"https://{GetApiEndpoint()}/rpc";
         }
@@ -48,7 +52,7 @@ namespace POGOLib.Net
 
         private string GetApiEndpoint()
         {
-            var response = SendRemoteProtocolCall(Configuration.ApiUrl, new Request
+            var response = SendRemoteProtocolCall(Constants.ApiUrl, new Request
             {
                 RequestType = RequestType.GetPlayer
             });
@@ -79,6 +83,10 @@ namespace POGOLib.Net
             return GetMapObjectsResponse.Parser.ParseFrom(response.Returns[0]);
         }
 
+        /// <summary>
+        /// Gets the player profile parsed from a response of the <see cref="RpcClient"/>.
+        /// </summary>
+        /// <returns></returns>
         public LocalPlayer GetProfile()
         {
             var response = SendRemoteProtocolCall(_apiUrl, new Request

--- a/POGOLib/POGOLib.csproj
+++ b/POGOLib/POGOLib.csproj
@@ -64,7 +64,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Configuration.cs" />
+    <Compile Include="Constants.cs" />
     <Compile Include="Net\Data\GpsData.cs" />
     <Compile Include="Net\Data\SaveData.cs" />
     <Compile Include="Net\PoClient.cs" />

--- a/POGOLib/Pokemon/LoginProvider.cs
+++ b/POGOLib/Pokemon/LoginProvider.cs
@@ -1,7 +1,11 @@
 ﻿namespace POGOLib.Pokemon
 {
+    /// <summary>
+    /// Represents a login provider, used to authenticate with a <see cref="POGOLib.Net.PoClient"/>.
+    /// </summary>
     public enum LoginProvider
     {
-        PokemonTrainerClub = 0, GoogleAuth = 1
+        PokemonTrainerClub,
+        GoogleAuth
     }
 }


### PR DESCRIPTION
### Added some convention-specific documentation

I was getting tired of seeing non-documented members, so I took my time to add some basic documentation.
### Renamed Configuration.cs to Constants.cs

It's faulty to call this class `Configuration.cs`, as the user can't configure the settings. 
The class stores all constants, which means it's correct to call it `Constants.cs` instead.
### Renamed property HeartBeating to IsHeartbeating

There's a naming convention specifying that a bool should have a prefix of **is** where applicable.
I also don't understand why you had capitalized "Beating", as you are determining whether you are _sending_ heartbeats, not whether the heart is beating.
### Created a property instead of two methods

You had two methods called `SetGpsData()` and `GetGpsData()`, and all you were doing was setting a property inside `ClientData`. When you define a property, it actually creates one get and one set method internally, so there's no need to define them both.
### Replaced an if statement with a switch

In the `Authenticate()` method of `PoClient.cs`, you had an if statement deciding which one of the `LoginProvider.cs` options to choose. It's preferred to use a switch statement instead.
### Modified the members inside the LoginProvider enumeration

You don't need to add values to the specific members, unless you are actually going to use the values somewhere.
