### PR TITLE
Break infinite loop when pokemon account is banned

### DIFF
--- a/POGOLib.Official/Net/RpcClient.cs
+++ b/POGOLib.Official/Net/RpcClient.cs
@@ -114,6 +114,7 @@ namespace POGOLib.Official.Net
         {
             // Send GetPlayer to check if we're connected and authenticated
             GetPlayerResponse playerResponse;
+            var tries = 5;
             do
             {
                 var response = await SendRemoteProcedureCallAsync(new[]
@@ -136,11 +137,12 @@ namespace POGOLib.Official.Net
                 {
                     await Task.Delay(TimeSpan.FromMilliseconds(1000));
                 }
-            } while (!playerResponse.Success);
+                tries --;
+            } while (!playerResponse.Success && tries > 0);
 
             _session.Player.Data = playerResponse.PlayerData;
 
-            return true;
+            return (tries>0);
         }
 
         // TODO: Reimplement

--- a/POGOLib.Official/Pokemon/Map.cs
+++ b/POGOLib.Official/Pokemon/Map.cs
@@ -39,7 +39,7 @@ namespace POGOLib.Official.Pokemon
             internal set
             {
                 _cells = value;
-                Update?.Invoke(this, EventArgs.Empty);
+                Update?.Invoke(_session, EventArgs.Empty);
             }
         }
 

--- a/POGOLib.Official/Pokemon/Player.cs
+++ b/POGOLib.Official/Pokemon/Player.cs
@@ -31,6 +31,7 @@ namespace POGOLib.Official.Pokemon
         /// </summary>
         public double Longitude => Coordinate.Longitude;
 
+        public double Altitude => Coordinate.Altitude;
         /// <summary>
         ///     Gets the <see cref="Inventory" /> of the <see cref="Player" />
         /// </summary>

--- a/POGOLib.Official/Util/Hash/PokeHashHasher.cs
+++ b/POGOLib.Official/Util/Hash/PokeHashHasher.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -21,8 +22,8 @@ namespace POGOLib.Official.Util.Hash
     ///     to buy an API key, go to this url.
     ///     https://talk.pogodev.org/d/51-api-hashing-service-by-pokefarmer
     /// 
-    ///     Android version: 0.51.0
-    ///     IOS version: 1.21.0
+    ///     Android version: 0.57.4
+    ///     IOS version: 1.27.1
     /// </summary>
     public class PokeHashHasher : IHasher
     {
@@ -218,9 +219,12 @@ namespace POGOLib.Official.Util.Hash
                     int rateRequestsRemaining;
                     int ratePeriodEndSeconds;
 
-                    if (response.Headers.TryGetValues("X-MaxRequestCount", out IEnumerable<string> maxRequestsValue) &&
-                        response.Headers.TryGetValues("X-RateRequestsRemaining", out IEnumerable<string> requestsRemainingValue) &&
-                        response.Headers.TryGetValues("X-RatePeriodEnd", out IEnumerable<string> ratePeriodEndValue))
+                    IEnumerable<string> maxRequestsValue;
+                    IEnumerable<string> requestsRemainingValue;
+                    IEnumerable<string> ratePeriodEndValue;
+                    if (response.Headers.TryGetValues("X-MaxRequestCount", out  maxRequestsValue) &&
+                        response.Headers.TryGetValues("X-RateRequestsRemaining", out  requestsRemainingValue) &&
+                        response.Headers.TryGetValues("X-RatePeriodEnd", out  ratePeriodEndValue))
                     {
                         if (!int.TryParse(maxRequestsValue.First(), out maxRequestCount) ||
                             !int.TryParse(requestsRemainingValue.First(), out rateRequestsRemaining) ||


### PR DESCRIPTION
Break infinite loop when pokemon account is banned
Changed map update sender to "session" to can interact with the session that have updated when we are using multiple sessions.