### PR TITLE
Updates for 0.59.1 API

### DIFF
--- a/POGOLib.Official/Net/Session.cs
+++ b/POGOLib.Official/Net/Session.cs
@@ -147,7 +147,7 @@ namespace POGOLib.Official.Net
 
             var pogoVersion = new Version(pogoVersionRaw);
             var result = Configuration.Hasher.PokemonVersion.CompareTo(pogoVersion);
-            if (result != 0)
+            if (result < 0)
             {
                 throw new HashVersionMismatchException($"The version of the {nameof(Configuration.Hasher)} ({Configuration.Hasher.PokemonVersion}) does not match the minimal API version of PokemonGo ({pogoVersion}). Set 'Configuration.IgnoreHashVersion' to true if you want to disable the version check.");
             }

--- a/POGOLib.Official/POGOLib.Official.csproj
+++ b/POGOLib.Official/POGOLib.Official.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="GeoCoordinate.NetStandard1" Version="1.0.0" />
-    <PackageReference Include="POGOProtos.NetStandard1" Version="2.7.0" />
+    <PackageReference Include="POGOProtos.NetStandard1" Version="2.8.0" />
     <PackageReference Include="Google.Protobuf" Version="3.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="S2Geometry" Version="1.0.3" />

--- a/POGOLib.Official/Util/Encryption/PokeHash/PCryptPokeHash.cs
+++ b/POGOLib.Official/Util/Encryption/PokeHash/PCryptPokeHash.cs
@@ -1,222 +1,100 @@
 ﻿using System;
-using System.Collections.ObjectModel;
-using System.Linq;
-using POGOLib.Official.Util.Encryption.Legacy;
 
 namespace POGOLib.Official.Util.Encryption.PokeHash
 {
     /// <summary>
     ///     This is the PCrypt used by POGOLib. It should always match the used PokeHash version.
     /// 
-    ///     Android version: 0.51.0
-    ///     IOS version: 1.21.0
+    ///     Android version: 0.59.1
+    ///     IOS version: 1.29.1
     /// </summary>
     internal static class PCryptPokeHash
     {
-        private static byte Rot18(byte val, int bits)
-        {
-            return (byte)(((val << bits) | (val >> (8 - bits))) & 0xff);
-        }
+		public static byte[] KEY = new byte[]
+		{
+			(byte) 0x4F, (byte) 0xEB, (byte) 0x1C, (byte) 0xA5, (byte) 0xF6, (byte) 0x1A, (byte) 0x67, (byte) 0xCE,
+			(byte) 0x43, (byte) 0xF3, (byte) 0xF0, (byte) 0x0C, (byte) 0xB1, (byte) 0x23, (byte) 0x88, (byte) 0x35,
+			(byte) 0xE9, (byte) 0x8B, (byte) 0xE8, (byte) 0x39, (byte) 0xD8, (byte) 0x89, (byte) 0x8F, (byte) 0x5A,
+			(byte) 0x3B, (byte) 0x51, (byte) 0x2E, (byte) 0xA9, (byte) 0x47, (byte) 0x38, (byte) 0xC4, (byte) 0x14
+		};
+			
+		public static byte[] MakeIv(Rand rand)
+		{
+			byte[] iv = new byte[TwoFish.BLOCK_SIZE];
+			for (int i = 0; i < iv.Length; i++)
+			{
+				iv[i] = rand.Next();
+			}
+			return iv;
+		}
 
-        private static byte GenerateRand(ref uint rand)
-        {
-            rand = rand * 0x41c64e6d + 12345;
-            return (byte)((rand >> 16) & 0xff);
-        }
+		public static byte MakeIntegrityByte(Rand rand)
+		{
+			return 0x21;
+		}
 
-        private static byte[] Cipher8FromIv(byte[] iv)
-        {
-            var ret = new byte[256];
-            for (var i = 0; i < 8; i++)
-            {
-                for (var j = 0; j < 32; j++)
-                {
-                    ret[32 * i * j] = Rot18(iv[j], i);
-                }
-            }
-            return ret;
-        }
+		/**
+			* Encrypts the given signature
+			*
+			* @param input input data
+			* @param msSinceStart time since start
+			* @return encrypted signature
+			*/
+		public static byte[] Encrypt(byte[] input, uint msSinceStart)
+		{
+			try
+			{
+				object[] key = TwoFish.MakeKey(KEY);
 
-        private static byte[] Cipher8FromRand(ref uint rand)
-        {
-            var ret = new byte[256];
-            for (var i = 0; i < 256; i++)
-            {
-                ret[i] = GenerateRand(ref rand);
-            }
-            return ret;
-        }
+				Rand rand = new Rand(msSinceStart);
+				byte[] iv = MakeIv(rand);
+				int blockCount = (input.Length + 256) / 256;
+				int outputSize = (blockCount * 256) + 5;
+				byte[] output = new byte[outputSize];
 
-        private static byte MakeIntegrityByte(byte b)
-        {
-            return (byte)(b & 0xe3 | 0x10);
-        }
+				output[0] = (byte)(msSinceStart >> 24);
+				output[1] = (byte)(msSinceStart >> 16);
+				output[2] = (byte)(msSinceStart >> 8);
+				output[3] = (byte)msSinceStart;
 
-        public static byte[] Encrypt(byte[] input, uint ms)
-        {
-            var ct = new CipherText(input, ms);
-            var iv = Cipher8FromRand(ref ms);
+				Array.Copy(input, 0, output, 4, input.Length);
+				output[outputSize - 2] = (byte)(256 - input.Length % 256);
 
-            //encrypt
-            foreach (var bytes in ct.Content)
-            {
-                for (var j = 0; j < 256; j++)
-                {
-                    bytes[j] ^= iv[j];
-                }
+				for (int offset = 0; offset < blockCount * 256; offset += TwoFish.BLOCK_SIZE)
+				{
+					for (int i = 0; i < TwoFish.BLOCK_SIZE; i++)
+					{
+						output[4 + offset + i] ^= iv[i];
+					}
 
-                var temp2 = new uint[0x100 / 4];
-                Buffer.BlockCopy(bytes, 0, temp2, 0, 0x100);
-                ShufflesLegacy.Shuffle2(temp2);
+					byte[] block = TwoFish.blockEncrypt(output, offset + 4, key);
+					Array.Copy(block, 0, output, offset + 4, block.Length);
+					Array.Copy(output, 4 + offset, iv, 0, TwoFish.BLOCK_SIZE);
+				}
 
-                Buffer.BlockCopy(temp2, 0, iv, 0, 0x100);
-                Buffer.BlockCopy(temp2, 0, bytes, 0, 0x100);
-            }
+				output[outputSize - 1] = MakeIntegrityByte(rand);
+				return output;
+			}
+			catch (Exception)
+			{
+				return null;
+			}
+		}
 
-            return ct.GetBytes(ref ms);
-        }
+		public class Rand
+		{
+			private long state;
 
-        //this returns an empty buffer if error
-        public static byte[] Decrypt(byte[] input, out int length)
-        {
-            int version, len = input.Length;
-            if (len < 261)
-            {
-                length = 0;
-                return new byte[] { };
-            }
+			public Rand(long state)
+			{
+				this.state = state;
+			}
 
-            var modSize = len % 256;
-            switch (modSize)
-            {
-                case 32:
-                    version = 1;
-                    break;
-                case 33:
-                    version = 2;
-                    break;
-                case 5:
-                    version = 3;
-                    break;
-                default:
-                    length = 0; return new byte[] { };
-            }
-
-            byte[] cipher8, output;
-            int outputLen;
-            switch (version)
-            {
-                case 1:
-                    outputLen = len - 32;
-                    output = new byte[outputLen];
-                    Buffer.BlockCopy(input, 32, output, 0, outputLen);
-                    cipher8 = Cipher8FromIv(input);
-                    break;
-                case 2:
-                    outputLen = len - 33;
-                    output = new byte[outputLen];
-                    Buffer.BlockCopy(input, 32, output, 0, outputLen);
-                    cipher8 = Cipher8FromIv(input);
-                    break;
-                default:
-                    outputLen = len - 5;
-                    output = new byte[outputLen];
-                    Buffer.BlockCopy(input, 4, output, 0, outputLen);
-                    var tmp = new byte[4];
-                    Buffer.BlockCopy(input, 0, tmp, 0, 4);
-                    Array.Reverse(tmp);
-                    var ms = BitConverter.ToUInt32(tmp, 0);
-                    cipher8 = Cipher8FromRand(ref ms);
-                    if (input[len - 1] != MakeIntegrityByte(GenerateRand(ref ms))) { length = 0; return new byte[] { }; }
-                    break;
-            }
-
-            var outputcontent = new Collection<byte[]>();
-
-            //break into chunks of 256
-            var roundedsize = (outputLen + 255) / 256; //round up
-            for (var i = 0; i < roundedsize; i++)
-                outputcontent.Add(new byte[256]);
-            for (var i = 0; i < outputLen; i++)
-                outputcontent[i / 256][i % 256] = output[i];
-
-            foreach (var bytes in outputcontent)
-            {
-                var temp2 = new uint[0x100 / 4];
-                var temp3 = new uint[0x100 / 4];
-                Buffer.BlockCopy(bytes, 0, temp2, 0, 0x100);
-                Buffer.BlockCopy(temp2, 0, temp3, 0, 0x100);
-
-                if (version == 1)
-                    ShufflesLegacy.Unshuffle(temp2);
-                else
-                    ShufflesLegacy.Unshuffle2(temp2);
-
-                Buffer.BlockCopy(temp2, 0, bytes, 0, 0x100);
-                for (var j = 0; j < 256; j++)
-                {
-                    bytes[j] ^= cipher8[j];
-                }
-                Buffer.BlockCopy(temp3, 0, cipher8, 0, 0x100);
-            }
-
-            var ret = new byte[outputLen];
-            for (var i = 0; i < outputcontent.Count; i++)
-            {
-                Buffer.BlockCopy(outputcontent[i], 0, ret, i * 256, 0x100);
-            }
-            length = outputLen - ret.Last();
-            return ret;
-        }
-
-        private class CipherText
-        {
-            private readonly byte[] _prefix;
-            private readonly int _totalsize;
-
-            public readonly Collection<byte[]> Content;
-
-            private static byte[] IntToBytes(int x)
-            {
-                return BitConverter.GetBytes(x);
-            }
-
-            public CipherText(byte[] input, uint ms)
-            {
-                var inputlen = input.Length;
-                _prefix = new byte[32];
-
-                //allocate blocks of 256 bytes
-                Content = new Collection<byte[]>();
-                var roundedsize = inputlen + (256 - (inputlen % 256));
-                for (var i = 0; i < roundedsize / 256; i++)
-                    Content.Add(new byte[256]);
-                _totalsize = roundedsize + 5;
-
-                //first 32 bytes, pcrypt.c:68
-                _prefix = IntToBytes((int)ms);
-                Array.Reverse(_prefix);
-
-                //split input into 256
-                for (var i = 0; i < inputlen; i++) Content[i / 256][i % 256] = input[i];
-
-                //pcrypt.c:75
-                Content.Last()[Content.Last().Length - 1] = (byte)(256 - (input.Length % 256));
-            }
-
-            public byte[] GetBytes(ref uint ms)
-            {
-                var ret = new byte[_totalsize];
-                Buffer.BlockCopy(_prefix, 0, ret, 0, _prefix.Length);
-                var offset = _prefix.Length;
-                foreach (var bytes in Content)
-                {
-                    Buffer.BlockCopy(bytes, 0, ret, offset, bytes.Length);
-                    offset += bytes.Length;
-                }
-                ret[ret.Length - 1] = MakeIntegrityByte(GenerateRand(ref ms));
-                return ret;
-            }
-        }
+			public byte Next()
+			{
+				state = (state * 0x41C64E6D) + 0x3039;
+				return (byte)((state >> 16) & 0xFF);
+			}
+		}
     }
 }

--- a/POGOLib.Official/Util/Encryption/PokeHash/TwoFish.cs
+++ b/POGOLib.Official/Util/Encryption/PokeHash/TwoFish.cs
@@ -1,0 +1,603 @@
+using System;
+
+namespace POGOLib.Official.Util.Encryption.PokeHash
+{
+    public static class TwoFish
+    {
+        public static int BLOCK_SIZE = 16;
+        private static int ROUNDS = 16;
+
+        private static int INPUT_WHITEN = 0;
+        private static int OUTPUT_WHITEN = INPUT_WHITEN + BLOCK_SIZE / 4;
+        private static int ROUND_SUBKEYS = OUTPUT_WHITEN + BLOCK_SIZE / 4;
+
+        private static int SK_STEP = 0x02020202;
+        private static int SK_BUMP = 0x01010101;
+        private static int SK_ROTL = 9;
+
+        /**
+         * Fixed 8x8 permutation S-boxes
+         */
+        private static byte[][] P = new byte[2][]
+		{
+            new byte[256]{
+                    (byte) 0xA9, (byte) 0x67, (byte) 0xB3, (byte) 0xE8,
+                    (byte) 0x04, (byte) 0xFD, (byte) 0xA3, (byte) 0x76,
+                    (byte) 0x9A, (byte) 0x92, (byte) 0x80, (byte) 0x78,
+                    (byte) 0xE4, (byte) 0xDD, (byte) 0xD1, (byte) 0x38,
+                    (byte) 0x0D, (byte) 0xC6, (byte) 0x35, (byte) 0x98,
+                    (byte) 0x18, (byte) 0xF7, (byte) 0xEC, (byte) 0x6C,
+                    (byte) 0x43, (byte) 0x75, (byte) 0x37, (byte) 0x26,
+                    (byte) 0xFA, (byte) 0x13, (byte) 0x94, (byte) 0x48,
+                    (byte) 0xF2, (byte) 0xD0, (byte) 0x8B, (byte) 0x30,
+                    (byte) 0x84, (byte) 0x54, (byte) 0xDF, (byte) 0x23,
+                    (byte) 0x19, (byte) 0x5B, (byte) 0x3D, (byte) 0x59,
+                    (byte) 0xF3, (byte) 0xAE, (byte) 0xA2, (byte) 0x82,
+                    (byte) 0x63, (byte) 0x01, (byte) 0x83, (byte) 0x2E,
+                    (byte) 0xD9, (byte) 0x51, (byte) 0x9B, (byte) 0x7C,
+                    (byte) 0xA6, (byte) 0xEB, (byte) 0xA5, (byte) 0xBE,
+                    (byte) 0x16, (byte) 0x0C, (byte) 0xE3, (byte) 0x61,
+                    (byte) 0xC0, (byte) 0x8C, (byte) 0x3A, (byte) 0xF5,
+                    (byte) 0x73, (byte) 0x2C, (byte) 0x25, (byte) 0x0B,
+                    (byte) 0xBB, (byte) 0x4E, (byte) 0x89, (byte) 0x6B,
+                    (byte) 0x53, (byte) 0x6A, (byte) 0xB4, (byte) 0xF1,
+                    (byte) 0xE1, (byte) 0xE6, (byte) 0xBD, (byte) 0x45,
+                    (byte) 0xE2, (byte) 0xF4, (byte) 0xB6, (byte) 0x66,
+                    (byte) 0xCC, (byte) 0x95, (byte) 0x03, (byte) 0x56,
+                    (byte) 0xD4, (byte) 0x1C, (byte) 0x1E, (byte) 0xD7,
+                    (byte) 0xFB, (byte) 0xC3, (byte) 0x8E, (byte) 0xB5,
+                    (byte) 0xE9, (byte) 0xCF, (byte) 0xBF, (byte) 0xBA,
+                    (byte) 0xEA, (byte) 0x77, (byte) 0x39, (byte) 0xAF,
+                    (byte) 0x33, (byte) 0xC9, (byte) 0x62, (byte) 0x71,
+                    (byte) 0x81, (byte) 0x79, (byte) 0x09, (byte) 0xAD,
+                    (byte) 0x24, (byte) 0xCD, (byte) 0xF9, (byte) 0xD8,
+                    (byte) 0xE5, (byte) 0xC5, (byte) 0xB9, (byte) 0x4D,
+                    (byte) 0x44, (byte) 0x08, (byte) 0x86, (byte) 0xE7,
+                    (byte) 0xA1, (byte) 0x1D, (byte) 0xAA, (byte) 0xED,
+                    (byte) 0x06, (byte) 0x70, (byte) 0xB2, (byte) 0xD2,
+                    (byte) 0x41, (byte) 0x7B, (byte) 0xA0, (byte) 0x11,
+                    (byte) 0x31, (byte) 0xC2, (byte) 0x27, (byte) 0x90,
+                    (byte) 0x20, (byte) 0xF6, (byte) 0x60, (byte) 0xFF,
+                    (byte) 0x96, (byte) 0x5C, (byte) 0xB1, (byte) 0xAB,
+                    (byte) 0x9E, (byte) 0x9C, (byte) 0x52, (byte) 0x1B,
+                    (byte) 0x5F, (byte) 0x93, (byte) 0x0A, (byte) 0xEF,
+                    (byte) 0x91, (byte) 0x85, (byte) 0x49, (byte) 0xEE,
+                    (byte) 0x2D, (byte) 0x4F, (byte) 0x8F, (byte) 0x3B,
+                    (byte) 0x47, (byte) 0x87, (byte) 0x6D, (byte) 0x46,
+                    (byte) 0xD6, (byte) 0x3E, (byte) 0x69, (byte) 0x64,
+                    (byte) 0x2A, (byte) 0xCE, (byte) 0xCB, (byte) 0x2F,
+                    (byte) 0xFC, (byte) 0x97, (byte) 0x05, (byte) 0x7A,
+                    (byte) 0xAC, (byte) 0x7F, (byte) 0xD5, (byte) 0x1A,
+                    (byte) 0x4B, (byte) 0x0E, (byte) 0xA7, (byte) 0x5A,
+                    (byte) 0x28, (byte) 0x14, (byte) 0x3F, (byte) 0x29,
+                    (byte) 0x88, (byte) 0x3C, (byte) 0x4C, (byte) 0x02,
+                    (byte) 0xB8, (byte) 0xDA, (byte) 0xB0, (byte) 0x17,
+                    (byte) 0x55, (byte) 0x1F, (byte) 0x8A, (byte) 0x7D,
+                    (byte) 0x57, (byte) 0xC7, (byte) 0x8D, (byte) 0x74,
+                    (byte) 0xB7, (byte) 0xC4, (byte) 0x9F, (byte) 0x72,
+                    (byte) 0x7E, (byte) 0x15, (byte) 0x22, (byte) 0x12,
+                    (byte) 0x58, (byte) 0x07, (byte) 0x99, (byte) 0x34,
+                    (byte) 0x6E, (byte) 0x50, (byte) 0xDE, (byte) 0x68,
+                    (byte) 0x65, (byte) 0xBC, (byte) 0xDB, (byte) 0xF8,
+                    (byte) 0xC8, (byte) 0xA8, (byte) 0x2B, (byte) 0x40,
+                    (byte) 0xDC, (byte) 0xFE, (byte) 0x32, (byte) 0xA4,
+                    (byte) 0xCA, (byte) 0x10, (byte) 0x21, (byte) 0xF0,
+                    (byte) 0xD3, (byte) 0x5D, (byte) 0x0F, (byte) 0x00,
+                    (byte) 0x6F, (byte) 0x9D, (byte) 0x36, (byte) 0x42,
+                    (byte) 0x4A, (byte) 0x5E, (byte) 0xC1, (byte) 0xE0
+            },
+            new byte[256] {
+                    (byte) 0x75, (byte) 0xF3, (byte) 0xC6, (byte) 0xF4,
+                    (byte) 0xDB, (byte) 0x7B, (byte) 0xFB, (byte) 0xC8,
+                    (byte) 0x4A, (byte) 0xD3, (byte) 0xE6, (byte) 0x6B,
+                    (byte) 0x45, (byte) 0x7D, (byte) 0xE8, (byte) 0x4B,
+                    (byte) 0xD6, (byte) 0x32, (byte) 0xD8, (byte) 0xFD,
+                    (byte) 0x37, (byte) 0x71, (byte) 0xF1, (byte) 0xE1,
+                    (byte) 0x30, (byte) 0x0F, (byte) 0xF8, (byte) 0x1B,
+                    (byte) 0x87, (byte) 0xFA, (byte) 0x06, (byte) 0x3F,
+                    (byte) 0x5E, (byte) 0xBA, (byte) 0xAE, (byte) 0x5B,
+                    (byte) 0x8A, (byte) 0x00, (byte) 0xBC, (byte) 0x9D,
+                    (byte) 0x6D, (byte) 0xC1, (byte) 0xB1, (byte) 0x0E,
+                    (byte) 0x80, (byte) 0x5D, (byte) 0xD2, (byte) 0xD5,
+                    (byte) 0xA0, (byte) 0x84, (byte) 0x07, (byte) 0x14,
+                    (byte) 0xB5, (byte) 0x90, (byte) 0x2C, (byte) 0xA3,
+                    (byte) 0xB2, (byte) 0x73, (byte) 0x4C, (byte) 0x54,
+                    (byte) 0x92, (byte) 0x74, (byte) 0x36, (byte) 0x51,
+                    (byte) 0x38, (byte) 0xB0, (byte) 0xBD, (byte) 0x5A,
+                    (byte) 0xFC, (byte) 0x60, (byte) 0x62, (byte) 0x96,
+                    (byte) 0x6C, (byte) 0x42, (byte) 0xF7, (byte) 0x10,
+                    (byte) 0x7C, (byte) 0x28, (byte) 0x27, (byte) 0x8C,
+                    (byte) 0x13, (byte) 0x95, (byte) 0x9C, (byte) 0xC7,
+                    (byte) 0x24, (byte) 0x46, (byte) 0x3B, (byte) 0x70,
+                    (byte) 0xCA, (byte) 0xE3, (byte) 0x85, (byte) 0xCB,
+                    (byte) 0x11, (byte) 0xD0, (byte) 0x93, (byte) 0xB8,
+                    (byte) 0xA6, (byte) 0x83, (byte) 0x20, (byte) 0xFF,
+                    (byte) 0x9F, (byte) 0x77, (byte) 0xC3, (byte) 0xCC,
+                    (byte) 0x03, (byte) 0x6F, (byte) 0x08, (byte) 0xBF,
+                    (byte) 0x40, (byte) 0xE7, (byte) 0x2B, (byte) 0xE2,
+                    (byte) 0x79, (byte) 0x0C, (byte) 0xAA, (byte) 0x82,
+                    (byte) 0x41, (byte) 0x3A, (byte) 0xEA, (byte) 0xB9,
+                    (byte) 0xE4, (byte) 0x9A, (byte) 0xA4, (byte) 0x97,
+                    (byte) 0x7E, (byte) 0xDA, (byte) 0x7A, (byte) 0x17,
+                    (byte) 0x66, (byte) 0x94, (byte) 0xA1, (byte) 0x1D,
+                    (byte) 0x3D, (byte) 0xF0, (byte) 0xDE, (byte) 0xB3,
+                    (byte) 0x0B, (byte) 0x72, (byte) 0xA7, (byte) 0x1C,
+                    (byte) 0xEF, (byte) 0xD1, (byte) 0x53, (byte) 0x3E,
+                    (byte) 0x8F, (byte) 0x33, (byte) 0x26, (byte) 0x5F,
+                    (byte) 0xEC, (byte) 0x76, (byte) 0x2A, (byte) 0x49,
+                    (byte) 0x81, (byte) 0x88, (byte) 0xEE, (byte) 0x21,
+                    (byte) 0xC4, (byte) 0x1A, (byte) 0xEB, (byte) 0xD9,
+                    (byte) 0xC5, (byte) 0x39, (byte) 0x99, (byte) 0xCD,
+                    (byte) 0xAD, (byte) 0x31, (byte) 0x8B, (byte) 0x01,
+                    (byte) 0x18, (byte) 0x23, (byte) 0xDD, (byte) 0x1F,
+                    (byte) 0x4E, (byte) 0x2D, (byte) 0xF9, (byte) 0x48,
+                    (byte) 0x4F, (byte) 0xF2, (byte) 0x65, (byte) 0x8E,
+                    (byte) 0x78, (byte) 0x5C, (byte) 0x58, (byte) 0x19,
+                    (byte) 0x8D, (byte) 0xE5, (byte) 0x98, (byte) 0x57,
+                    (byte) 0x67, (byte) 0x7F, (byte) 0x05, (byte) 0x64,
+                    (byte) 0xAF, (byte) 0x63, (byte) 0xB6, (byte) 0xFE,
+                    (byte) 0xF5, (byte) 0xB7, (byte) 0x3C, (byte) 0xA5,
+                    (byte) 0xCE, (byte) 0xE9, (byte) 0x68, (byte) 0x44,
+                    (byte) 0xE0, (byte) 0x4D, (byte) 0x43, (byte) 0x69,
+                    (byte) 0x29, (byte) 0x2E, (byte) 0xAC, (byte) 0x15,
+                    (byte) 0x59, (byte) 0xA8, (byte) 0x0A, (byte) 0x9E,
+                    (byte) 0x6E, (byte) 0x47, (byte) 0xDF, (byte) 0x34,
+                    (byte) 0x35, (byte) 0x6A, (byte) 0xCF, (byte) 0xDC,
+                    (byte) 0x22, (byte) 0xC9, (byte) 0xC0, (byte) 0x9B,
+                    (byte) 0x89, (byte) 0xD4, (byte) 0xED, (byte) 0xAB,
+                    (byte) 0x12, (byte) 0xA2, (byte) 0x0D, (byte) 0x52,
+                    (byte) 0xBB, (byte) 0x02, (byte) 0x2F, (byte) 0xA9,
+                    (byte) 0xD7, (byte) 0x61, (byte) 0x1E, (byte) 0xB4,
+                    (byte) 0x50, (byte) 0x04, (byte) 0xF6, (byte) 0xC2,
+                    (byte) 0x16, (byte) 0x25, (byte) 0x86, (byte) 0x56,
+                    (byte) 0x55, (byte) 0x09, (byte) 0xBE, (byte) 0x91
+            }
+		};
+
+        /**
+         * Define the fixed p0/p1 permutations used in keyed S-box lookup.
+         * By changing the following constant definitions, the S-boxes will
+         * automatically get changed in the Twofish engine.
+         */
+        private static int P_00 = 1;
+        private static int P_01 = 0;
+        private static int P_02 = 0;
+        private static int P_03 = P_01 ^ 1;
+        private static int P_04 = 1;
+
+        private static int P_10 = 0;
+        private static int P_11 = 0;
+        private static int P_12 = 1;
+        private static int P_13 = P_11 ^ 1;
+        private static int P_14 = 0;
+
+        private static int P_20 = 1;
+        private static int P_21 = 1;
+        private static int P_22 = 0;
+        private static int P_23 = P_21 ^ 1;
+        private static int P_24 = 0;
+
+        private static int P_30 = 0;
+        private static int P_31 = 1;
+        private static int P_32 = 1;
+        private static int P_33 = P_31 ^ 1;
+        private static int P_34 = 1;
+
+        /**
+         * Primitive polynomial for GF(256)
+         */
+        private static int GF256_FDBK_2 = 0x169 / 2;
+        private static int GF256_FDBK_4 = 0x169 / 4;
+
+        /**
+         * MDS matrix
+         */
+        private static int[][] MDS = new int[4][];
+
+        private static int RS_GF_FDBK = 0x14D;
+
+        static TwoFish()
+        {
+            int[] m1 = new int[2];
+            int[] mxArray = new int[2];
+            int[] myArray = new int[2];
+            int first;
+            int second = 0;
+
+            for (int i = 0; i < MDS.Length; i++)
+            {
+                MDS[i] = new int[256];
+            }
+
+            for (first = 0; first < 256; first++)
+            {
+                second = P[0][first] & 0xFF;
+                m1[0] = second;
+                mxArray[0] = mxX(second) & 0xFF;
+                myArray[0] = mxY(second) & 0xFF;
+
+                second = P[1][first] & 0xFF;
+                m1[1] = second;
+                mxArray[1] = mxX(second) & 0xFF;
+                myArray[1] = mxY(second) & 0xFF;
+
+                MDS[0][first] = m1[P_00]
+                        | mxArray[P_00] << 8
+                        | myArray[P_00] << 16
+                        | myArray[P_00] << 24;
+                MDS[1][first] = myArray[P_10]
+                        | myArray[P_10] << 8
+                        | mxArray[P_10] << 16
+                        | m1[P_10] << 24;
+                MDS[2][first] = mxArray[P_20]
+                        | myArray[P_20] << 8
+                        | m1[P_20] << 16
+                        | myArray[P_20] << 24;
+                MDS[3][first] = mxArray[P_30]
+                        | m1[P_30] << 8
+                        | myArray[P_30] << 16
+                        | mxArray[P_30] << 24;
+            }
+        }
+
+        private static int lfsr1(int x)
+        {
+            return (x >> 1) ^ ((x & 0x01) != 0 ? GF256_FDBK_2 : 0);
+        }
+
+        private static int lfsr2(int x)
+        {
+            return (x >> 2) ^ ((x & 0x02) != 0 ? GF256_FDBK_2 : 0) ^ ((x & 0x01) != 0 ? GF256_FDBK_4 : 0);
+        }
+
+        private static int mxX(int x)
+        {
+            return x ^ lfsr2(x);
+        }
+
+        private static int mxY(int x)
+        {
+            return x ^ lfsr1(x) ^ lfsr2(x);
+        }
+
+        /**
+         * Expand a user-supplied key material into a session key.
+         *
+         * @param k The 64/128/192/256-bit user-key to use.
+         * @return This cipher's round keys.
+         * @throws InvalidKeyException If the key is invalid.
+         */
+        public static object[] MakeKey(byte[] k)
+        {
+            if (k == null)
+                throw new Exception("Empty key");
+            int length = k.Length;
+            if (!(length == 8 || length == 16 || length == 24 || length == 32))
+                throw new Exception("Incorrect key length");
+
+            int k64Cnt = length / 8;
+            int subkeyCnt = ROUND_SUBKEYS + 2 * ROUNDS;
+            int[] k32e = new int[4];
+            int[] k32o = new int[4];
+            int[] sBoxKey = new int[4];
+            int i, j, offset = 0;
+            for (i = 0, j = k64Cnt - 1; i < 4 && offset < length; i++, j--)
+            {
+                k32e[i] = (k[offset++] & 0xFF)
+                        | (k[offset++] & 0xFF) << 8
+                        | (k[offset++] & 0xFF) << 16
+                        | (k[offset++] & 0xFF) << 24;
+                k32o[i] = (k[offset++] & 0xFF)
+                        | (k[offset++] & 0xFF) << 8
+                        | (k[offset++] & 0xFF) << 16
+                        | (k[offset++] & 0xFF) << 24;
+                sBoxKey[j] = rsMdsEncode(k32e[i], k32o[i]);
+            }
+            int q, A, B;
+            int[] subKeys = new int[subkeyCnt];
+            for (i = q = 0; i < subkeyCnt / 2; i++, q += SK_STEP)
+            {
+                A = f32(k64Cnt, q, k32e);
+                B = f32(k64Cnt, q + SK_BUMP, k32o);
+                B = B << 8 | RightUShift(B, 24);
+                A += B;
+                subKeys[2 * i] = A;
+                A += B;
+                subKeys[2 * i + 1] = A << SK_ROTL | RightUShift(A, (32 - SK_ROTL));
+            }
+            int k0 = sBoxKey[0];
+            int k1 = sBoxKey[1];
+            int k2 = sBoxKey[2];
+            int k3 = sBoxKey[3];
+            int b0, b1, b2, b3;
+            int[] sBox = new int[4 * 256];
+            for (i = 0; i < 256; i++)
+            {
+                b0 = b1 = b2 = b3 = i;
+
+                int val = k64Cnt & 3;
+
+                if (val == 1)
+                {
+                    sBox[2 * i] = MDS[0][(P[P_01][b0] & 0xFF) ^ _b0(k0)];
+                    sBox[2 * i + 1] = MDS[1][(P[P_11][b1] & 0xFF) ^ _b1(k0)];
+                    sBox[0x200 + 2 * i] = MDS[2][(P[P_21][b2] & 0xFF) ^ _b2(k0)];
+                    sBox[0x200 + 2 * i + 1] = MDS[3][(P[P_31][b3] & 0xFF) ^ _b3(k0)];
+                }
+                switch (k64Cnt & 3)
+                {
+                    case 1:
+                        sBox[2 * i] = MDS[0][(P[P_01][b0] & 0xFF) ^ _b0(k0)];
+                        sBox[2 * i + 1] = MDS[1][(P[P_11][b1] & 0xFF) ^ _b1(k0)];
+                        sBox[0x200 + 2 * i] = MDS[2][(P[P_21][b2] & 0xFF) ^ _b2(k0)];
+                        sBox[0x200 + 2 * i + 1] = MDS[3][(P[P_31][b3] & 0xFF) ^ _b3(k0)];
+                        break;
+                    case 0:
+                        b0 = (P[P_04][b0] & 0xFF) ^ _b0(k3);
+                        b1 = (P[P_14][b1] & 0xFF) ^ _b1(k3);
+                        b2 = (P[P_24][b2] & 0xFF) ^ _b2(k3);
+                        b3 = (P[P_34][b3] & 0xFF) ^ _b3(k3);
+
+
+                        b0 = (P[P_03][b0] & 0xFF) ^ _b0(k2);
+                        b1 = (P[P_13][b1] & 0xFF) ^ _b1(k2);
+                        b2 = (P[P_23][b2] & 0xFF) ^ _b2(k2);
+                        b3 = (P[P_33][b3] & 0xFF) ^ _b3(k2);
+
+
+                        sBox[2 * i] = MDS[0][(P[P_01][(P[P_02][b0] & 0xFF) ^ _b0(k1)] & 0xFF) ^ _b0(k0)];
+                        sBox[2 * i + 1] = MDS[1][(P[P_11][(P[P_12][b1] & 0xFF) ^ _b1(k1)] & 0xFF) ^ _b1(k0)];
+                        sBox[0x200 + 2 * i] = MDS[2][(P[P_21][(P[P_22][b2] & 0xFF) ^ _b2(k1)] & 0xFF) ^ _b2(k0)];
+                        sBox[0x200 + 2 * i + 1] = MDS[3][(P[P_31][(P[P_32][b3] & 0xFF) ^ _b3(k1)] & 0xFF) ^ _b3(k0)];
+                        break;
+                    case 3:
+                        b0 = (P[P_03][b0] & 0xFF) ^ _b0(k2);
+                        b1 = (P[P_13][b1] & 0xFF) ^ _b1(k2);
+                        b2 = (P[P_23][b2] & 0xFF) ^ _b2(k2);
+                        b3 = (P[P_33][b3] & 0xFF) ^ _b3(k2);
+
+                        sBox[2 * i] = MDS[0][(P[P_01][(P[P_02][b0] & 0xFF) ^ _b0(k1)] & 0xFF) ^ _b0(k0)];
+                        sBox[2 * i + 1] = MDS[1][(P[P_11][(P[P_12][b1] & 0xFF) ^ _b1(k1)] & 0xFF) ^ _b1(k0)];
+                        sBox[0x200 + 2 * i] = MDS[2][(P[P_21][(P[P_22][b2] & 0xFF) ^ _b2(k1)] & 0xFF) ^ _b2(k0)];
+                        sBox[0x200 + 2 * i + 1] = MDS[3][(P[P_31][(P[P_32][b3] & 0xFF) ^ _b3(k1)] & 0xFF) ^ _b3(k0)];
+                        break;
+                    case 2:
+                        sBox[2 * i] = MDS[0][(P[P_01][(P[P_02][b0] & 0xFF) ^ _b0(k1)] & 0xFF) ^ _b0(k0)];
+                        sBox[2 * i + 1] = MDS[1][(P[P_11][(P[P_12][b1] & 0xFF) ^ _b1(k1)] & 0xFF) ^ _b1(k0)];
+                        sBox[0x200 + 2 * i] = MDS[2][(P[P_21][(P[P_22][b2] & 0xFF) ^ _b2(k1)] & 0xFF) ^ _b2(k0)];
+                        sBox[0x200 + 2 * i + 1] = MDS[3][(P[P_31][(P[P_32][b3] & 0xFF) ^ _b3(k1)] & 0xFF) ^ _b3(k0)];
+                        break;
+                }
+            }
+            return new object[] { sBox, subKeys };
+        }
+
+        public static int RightUShift(int val, int shift)
+        {
+            return (int)((uint)val >> shift);
+        }
+
+        /**
+         * Encrypt exactly one block of plaintext.
+         *
+         * @param in The plaintext.
+         * @param inOffset Index of in from which to start considering data.
+         * @param sessionKey The session key to use for encryption.
+         * @return The ciphertext generated from a plaintext using the session key.
+         */
+        public static byte[] blockEncrypt(byte[] bArray, int inOffset, Object sessionKey)
+        {
+            Object[] sk = (Object[])sessionKey;
+            int[] sBox = (int[])sk[0];
+            int[] sKey = (int[])sk[1];
+
+            int x0 = (bArray[inOffset++] & 0xFF)
+                    | (bArray[inOffset++] & 0xFF) << 8
+                    | (bArray[inOffset++] & 0xFF) << 16
+                    | (bArray[inOffset++] & 0xFF) << 24;
+            int x1 = (bArray[inOffset++] & 0xFF)
+                    | (bArray[inOffset++] & 0xFF) << 8
+                    | (bArray[inOffset++] & 0xFF) << 16
+                    | (bArray[inOffset++] & 0xFF) << 24;
+            int x2 = (bArray[inOffset++] & 0xFF)
+                    | (bArray[inOffset++] & 0xFF) << 8
+                    | (bArray[inOffset++] & 0xFF) << 16
+                    | (bArray[inOffset++] & 0xFF) << 24;
+            int x3 = (bArray[inOffset++] & 0xFF)
+                    | (bArray[inOffset++] & 0xFF) << 8
+                    | (bArray[inOffset++] & 0xFF) << 16
+                    | (bArray[inOffset++] & 0xFF) << 24;
+
+            x0 ^= sKey[INPUT_WHITEN];
+            x1 ^= sKey[INPUT_WHITEN + 1];
+            x2 ^= sKey[INPUT_WHITEN + 2];
+            x3 ^= sKey[INPUT_WHITEN + 3];
+
+            int t0, t1;
+            int k = ROUND_SUBKEYS;
+            for (int R = 0; R < ROUNDS; R += 2)
+            {
+                t0 = fe32(sBox, x0, 0);
+                t1 = fe32(sBox, x1, 3);
+                x2 ^= t0 + t1 + sKey[k++];
+                x2 = RightUShift(x2, 1) | x2 << 31;
+                x3 = x3 << 1 | RightUShift(x3, 31);
+                x3 ^= t0 + 2 * t1 + sKey[k++];
+
+                t0 = fe32(sBox, x2, 0);
+                t1 = fe32(sBox, x3, 3);
+                x0 ^= t0 + t1 + sKey[k++];
+                x0 = RightUShift(x0, 1) | x0 << 31;
+                x1 = x1 << 1 | RightUShift(x1, 31);
+                x1 ^= t0 + 2 * t1 + sKey[k++];
+            }
+            x2 ^= sKey[OUTPUT_WHITEN];
+            x3 ^= sKey[OUTPUT_WHITEN + 1];
+            x0 ^= sKey[OUTPUT_WHITEN + 2];
+            x1 ^= sKey[OUTPUT_WHITEN + 3];
+
+            return new byte[]{
+                (byte) x2, (byte) RightUShift(x2, 8), (byte) RightUShift(x2, 16), (byte) RightUShift(x2, 24),
+                (byte) x3, (byte) RightUShift(x3, 8), (byte) RightUShift(x3, 16), (byte) RightUShift(x3, 24),
+                (byte) x0, (byte) RightUShift(x0, 8), (byte) RightUShift(x0, 16), (byte) RightUShift(x0, 24),
+                (byte) x1, (byte) RightUShift(x1, 8), (byte) RightUShift(x1, 16), (byte) RightUShift(x1, 24),
+            };
+        }
+
+        private static int _b0(int x) { return x & 0xFF; }
+
+        private static int _b1(int x) { return RightUShift(x, 8) & 0xFF; }
+
+        private static int _b2(int x) { return RightUShift(x, 16) & 0xFF; }
+
+        private static int _b3(int x) { return RightUShift(x, 24) & 0xFF; }
+
+        /**
+         * Use (12, 8) Reed-Solomon code over GF(256) to produce a key S-box
+         * 32-bit entity from two key material 32-bit entities.
+         *
+         * @param k0 1st 32-bit entity.
+         * @param k1 2nd 32-bit entity.
+         * @return Remainder polynomial generated using RS code
+         */
+        private static int rsMdsEncode(int k0, int k1)
+        {
+            int r = k1;
+            for (int i = 0; i < 4; i++)
+            {
+                r = rsRem(r);
+            }
+            r ^= k0;
+            for (int i = 0; i < 4; i++)
+            {
+                r = rsRem(r);
+            }
+            return r;
+        }
+
+        private static int rsRem(int x)
+        {
+            int b = RightUShift(x, 24) & 0xFF;
+            int g2 = ((b << 1) ^ ((b & 0x80) != 0 ? RS_GF_FDBK : 0)) & 0xFF;
+            int g3 = RightUShift(b, 1) ^ ((b & 0x01) != 0 ? RightUShift(RS_GF_FDBK, 1) : 0) ^ g2;
+            int result = (x << 8) ^ (g3 << 24) ^ (g2 << 16) ^ (g3 << 8) ^ b;
+            return result;
+        }
+
+        private static int f32(int k64Cnt, int x, int[] k32)
+        {
+            int b0 = _b0(x);
+            int b1 = _b1(x);
+            int b2 = _b2(x);
+            int b3 = _b3(x);
+            int k0 = k32[0];
+            int k1 = k32[1];
+            int k2 = k32[2];
+            int k3 = k32[3];
+
+            int result = 0;
+            switch (k64Cnt & 3)
+            {
+                case 1:
+                    result =
+                            MDS[0][(P[P_01][b0] & 0xFF)
+                                    ^ _b0(k0)]
+                                    ^ MDS[1][(P[P_11][b1] & 0xFF)
+                                    ^ _b1(k0)]
+                                    ^ MDS[2][(P[P_21][b2] & 0xFF)
+                                    ^ _b2(k0)]
+                                    ^ MDS[3][(P[P_31][b3] & 0xFF)
+                                    ^ _b3(k0)];
+                    break;
+                case 0:
+                    b0 = (P[P_04][b0] & 0xFF) ^ _b0(k3);
+                    b1 = (P[P_14][b1] & 0xFF) ^ _b1(k3);
+                    b2 = (P[P_24][b2] & 0xFF) ^ _b2(k3);
+                    b3 = (P[P_34][b3] & 0xFF) ^ _b3(k3);
+
+
+                    b0 = (P[P_03][b0] & 0xFF) ^ _b0(k2);
+                    b1 = (P[P_13][b1] & 0xFF) ^ _b1(k2);
+                    b2 = (P[P_23][b2] & 0xFF) ^ _b2(k2);
+                    b3 = (P[P_33][b3] & 0xFF) ^ _b3(k2);
+
+                    result =
+                            MDS[0][(P[P_01][(P[P_02][b0] & 0xFF)
+                                    ^ _b0(k1)] & 0xFF)
+                                    ^ _b0(k0)]
+                                    ^ MDS[1][(P[P_11][(P[P_12][b1] & 0xFF)
+                                    ^ _b1(k1)] & 0xFF) ^ _b1(k0)]
+                                    ^ MDS[2][(P[P_21][(P[P_22][b2] & 0xFF)
+                                    ^ _b2(k1)] & 0xFF)
+                                    ^ _b2(k0)]
+                                    ^ MDS[3][(P[P_31][(P[P_32][b3] & 0xFF)
+                                    ^ _b3(k1)] & 0xFF)
+                                    ^ _b3(k0)];
+                    break;
+                case 3:
+                    b0 = (P[P_03][b0] & 0xFF) ^ _b0(k2);
+                    b1 = (P[P_13][b1] & 0xFF) ^ _b1(k2);
+                    b2 = (P[P_23][b2] & 0xFF) ^ _b2(k2);
+                    b3 = (P[P_33][b3] & 0xFF) ^ _b3(k2);
+
+                    result =
+                            MDS[0][(P[P_01][(P[P_02][b0] & 0xFF)
+                                    ^ _b0(k1)] & 0xFF)
+                                    ^ _b0(k0)]
+                                    ^ MDS[1][(P[P_11][(P[P_12][b1] & 0xFF)
+                                    ^ _b1(k1)] & 0xFF) ^ _b1(k0)]
+                                    ^ MDS[2][(P[P_21][(P[P_22][b2] & 0xFF)
+                                    ^ _b2(k1)] & 0xFF)
+                                    ^ _b2(k0)]
+                                    ^ MDS[3][(P[P_31][(P[P_32][b3] & 0xFF)
+                                    ^ _b3(k1)] & 0xFF)
+                                    ^ _b3(k0)];
+                    break;
+                case 2:
+                    result =
+                            MDS[0][(P[P_01][(P[P_02][b0] & 0xFF)
+                                    ^ _b0(k1)] & 0xFF)
+                                    ^ _b0(k0)]
+                                    ^ MDS[1][(P[P_11][(P[P_12][b1] & 0xFF)
+                                    ^ _b1(k1)] & 0xFF) ^ _b1(k0)]
+                                    ^ MDS[2][(P[P_21][(P[P_22][b2] & 0xFF)
+                                    ^ _b2(k1)] & 0xFF)
+                                    ^ _b2(k0)]
+                                    ^ MDS[3][(P[P_31][(P[P_32][b3] & 0xFF)
+                                    ^ _b3(k1)] & 0xFF)
+                                    ^ _b3(k0)];
+                    break;
+            }
+            return result;
+        }
+
+        private static int fe32(int[] sBox, int x, int r)
+        {
+            return sBox[2 * b(x, r)]
+                    ^ sBox[2 * b(x, r + 1) + 1]
+                    ^ sBox[0x200 + 2 * b(x, r + 2)]
+                    ^ sBox[0x200 + 2 * b(x, r + 3) + 1];
+        }
+
+        private static int b(int x, int n)
+        {
+            int result = 0;
+            switch (n % 4)
+            {
+                case 0:
+                    result = _b0(x);
+                    break;
+                case 1:
+                    result = _b1(x);
+                    break;
+                case 2:
+                    result = _b2(x);
+                    break;
+                case 3:
+                    result = _b3(x);
+                    break;
+            }
+            return result;
+        }
+    }
+}

--- a/POGOLib.Official/Util/Hash/PokeHashHasher.cs
+++ b/POGOLib.Official/Util/Hash/PokeHashHasher.cs
@@ -21,14 +21,14 @@ namespace POGOLib.Official.Util.Hash
     ///     to buy an API key, go to this url.
     ///     https://talk.pogodev.org/d/51-api-hashing-service-by-pokefarmer
     /// 
-    ///     Android version: 0.51.0
-    ///     IOS version: 1.21.0
+    ///     Android version: 0.59.1
+    ///     IOS version: 1.29.1
     /// </summary>
     public class PokeHashHasher : IHasher
     {
         private const string PokeHashUrl = "https://pokehash.buddyauth.com/";
 
-        private const string PokeHashEndpoint = "api/v127_4/hash";
+        private const string PokeHashEndpoint = "api/v129_1/hash";
 
         private readonly List<PokeHashAuthKey> _authKeys;
 
@@ -79,9 +79,9 @@ namespace POGOLib.Official.Util.Hash
             _keySelection = new Semaphore(1, 1);
         }
 
-        public Version PokemonVersion { get; } = new Version("0.57.4");
+        public Version PokemonVersion { get; } = new Version("0.59.1");
 
-        public long Unknown25 { get; } = -816976800928766045;
+        public long Unknown25 { get; } = -3226782243204485589;
 
         public async Task<HashData> GetHashDataAsync(RequestEnvelope requestEnvelope, Signature signature, byte[] locationBytes, byte[][] requestsBytes, byte[] serializedTicket)
         {


### PR DESCRIPTION
Updates for 0.59.1:
- New encryption with TwoFish
- Updates to Unknown25 and versions.
- Update hashing server API url
- Change CheckHasherVersion to allow non-forced API to be used.  Currently 0.57.4 is the forced API version, but we should still be allowed to use 0.59.1.
- Update POGOProtos to 2.8.0

References:
https://github.com/Grover-c13/PokeGOAPI-Java/pull/898/files