### PR TITLE
Add GetInbox to EVERYTHING

### DIFF
--- a/POGOLib.Official/Net/RpcClient.cs
+++ b/POGOLib.Official/Net/RpcClient.cs
@@ -432,8 +432,7 @@ namespace POGOLib.Official.Net
                 requestEnvelope.AuthTicket = _session.AccessToken.AuthTicket;
             }
 
-            if (requestEnvelope.Requests.Count > 0 &&
-                requestEnvelope.Requests[0].RequestType == RequestType.GetMapObjects)
+            if (requestEnvelope.Requests.Count > 0)
             {
                 requestEnvelope.Requests.Add(new Request
                 {


### PR DESCRIPTION
So it turns out `GetInbox` is sent with **every RPC message**, so might as well update POGOLib accordingly.